### PR TITLE
fix: 인증 실패 시 401 오류로 통일 처리 (refs #이슈번호)

### DIFF
--- a/src/main/java/com/example/moyeorak/config/SecurityConfig.java
+++ b/src/main/java/com/example/moyeorak/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.moyeorak.config;
 
 import com.example.moyeorak.jwt.JwtAuthFilter;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,7 +29,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // Preflight 허용
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
                                 "/actuator/health", "/actuator/info", "/health",
                                 "/api/users/signup", "/api/users/login",
@@ -49,6 +50,14 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN")
                         .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증이 필요합니다.");
+                        })
+                        .accessDeniedHandler((request, response, accessDeniedException) -> {
+                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "접근 권한이 없습니다.");
+                        })
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 


### PR DESCRIPTION
✅ 작업 내용
JWT 인증 실패 시 403 Forbidden 대신 401 Unauthorized 응답으로 변경

Spring Security에서 JwtAuthFilter 예외 처리 개선

🛠️ 수정 이유
클라이언트에서 인증 실패(토큰 만료 등)를 명확히 구분할 수 있도록 하기 위함

보안상 적절한 HTTP 상태 코드 사용 (401: 인증 실패, 403: 권한 없음)