### PR TITLE
수강 신청 중 취소된 이력은 중복 신청 가능하도록 로직 수정 (refs #10)

### DIFF
--- a/src/main/java/com/example/moyeorak/config/SecurityConfig.java
+++ b/src/main/java/com/example/moyeorak/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.moyeorak.config;
 
 import com.example.moyeorak.jwt.JwtAuthFilter;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,7 +29,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // Preflight 허용
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers(
                                 "/actuator/health", "/actuator/info", "/health",
                                 "/api/users/signup", "/api/users/login",
@@ -49,6 +50,14 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers("/api/admin/**").hasAuthority("ROLE_ADMIN")
                         .anyRequest().authenticated()
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증이 필요합니다.");
+                        })
+                        .accessDeniedHandler((request, response, accessDeniedException) -> {
+                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "접근 권한이 없습니다.");
+                        })
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/example/moyeorak/repository/EnrollmentRepository.java
+++ b/src/main/java/com/example/moyeorak/repository/EnrollmentRepository.java
@@ -7,7 +7,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+
     boolean existsByUserIdAndProgramId(Long userId, Long programId);
+    boolean existsByUserIdAndProgramIdAndStatusNot(Long userId, Long programId, Enrollment.Status status);
     List<Enrollment> findByUserId(Long userId);
     Optional<Enrollment> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/example/moyeorak/service/EnrollmentService.java
+++ b/src/main/java/com/example/moyeorak/service/EnrollmentService.java
@@ -37,7 +37,9 @@ public class EnrollmentService {
         Program program = programRepository.findById(request.getProgramId())
                 .orElseThrow(() -> new IllegalArgumentException("프로그램 정보가 없습니다."));
 
-        if (enrollmentRepository.existsByUserIdAndProgramId(user.getId(), program.getId())) {
+        // ✅ 중복 수강 신청 체크 (CANCELLED 제외)
+        if (enrollmentRepository.existsByUserIdAndProgramIdAndStatusNot(
+                user.getId(), program.getId(), Enrollment.Status.CANCELLED)) {
             throw new IllegalArgumentException("이미 신청한 프로그램입니다.");
         }
 


### PR DESCRIPTION
## 작업 내용
- 수강 신청 시 중복 신청 여부 판단 로직에서 CANCELLED 상태를 제외하도록 수정
- EnrollmentRepository에 existsByUserIdAndProgramIdAndStatusNot 메서드 추가

## 이슈 설명
- 기존에는 status가 CANCELLED여도 중복 신청으로 간주되어 신청이 막힘
- 따라서 한번 취소한 수강 신청을 다시 신청할 수 없는 문제가 있었음

## 해결 방법
- 상태가 CANCELLED가 아닌 경우만 중복 신청으로 판단하도록 수정
- GET /api/enrollments/me 응답에서는 기존대로 status: "cancelled" 유지

## 관련 이슈
- closes #10